### PR TITLE
Define Vim line endings for DOS files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -96,8 +96,7 @@ RUN echo '' | tee -a /etc/ssh/ssh_config && \
   echo 'Include /etc/ssh/workspace' | tee -a /etc/ssh/ssh_config
 
 # configure user utilities
-RUN curl -sSLo /home/ubuntu/.eslintrc.json \
-  https://gist.githubusercontent.com/ashenm/537a91f9c864d6ef6180790d9076047d/raw/eslintrc.json
+ADD --chown=1000:1000 https://gist.githubusercontent.com/ashenm/537a91f9c864d6ef6180790d9076047d/raw/eslintrc.json /home/ubuntu/.eslintrc.json
 
 # configure system
 COPY etc /etc/

--- a/etc/vim/ftplugin/dosbatch.vim
+++ b/etc/vim/ftplugin/dosbatch.vim
@@ -1,0 +1,1 @@
+set fileformat=dos


### PR DESCRIPTION
- Define `\r\n` as line ends for DOS files (i.e. `.bat` or `.cmd`)
- Parity line ending schemes with enhancement #12
- Recast ownership of `/home/ubuntu/.eslintrc.json` to `ubuntu:ubuntu`